### PR TITLE
Fix for windows root path

### DIFF
--- a/src/Version.php
+++ b/src/Version.php
@@ -128,7 +128,7 @@ namespace SebastianBergmann
 
             $path = dirname($path);
 
-            if ($path == '/') {
+            if (strlen($path) == strlen(dirname($path))) {
                 return FALSE;
             }
 


### PR DESCRIPTION
Checking for '/' as root path will not work in windows so it just
spirals out of control and errors when it hits Max nesting (100 on my
machine).
