### PR TITLE
Always use last git segment.

### DIFF
--- a/src/Version.php
+++ b/src/Version.php
@@ -86,7 +86,7 @@ class Version
                 } else {
                     $git = explode('-', $git);
 
-                    $this->version = $this->release . '-' . $git[2];
+                    $this->version = $this->release . '-' . end($git);
                 }
             }
         }


### PR DESCRIPTION
This fixes an issue we're currently having where `git describe --tags` return `1.7.0-beta.2-208-g6d1683e`, and thus the version becomes `1.7-208` instead of `1.7-g6d1683e`.
