### PR TITLE
Explicitly specify git directory when running git

### DIFF
--- a/src/Version.php
+++ b/src/Version.php
@@ -63,12 +63,13 @@ final class Version
      */
     private function getGitInformation(string $path)
     {
-        if (!\is_dir($path . DIRECTORY_SEPARATOR . '.git')) {
+        $git_dir = $path . DIRECTORY_SEPARATOR . '.git';
+        if (!\is_dir($git_dir)) {
             return false;
         }
 
         $process = \proc_open(
-            'git describe --tags',
+            'git --git-dir="' . $git_dir . '" describe --tags',
             [
                 1 => ['pipe', 'w'],
                 2 => ['pipe', 'w'],


### PR DESCRIPTION
## Backstory
This was an interesting one track down. The symptom was that PHPStan only worked
when run directly, but not when run as part of a git invoked workflow (e.g. through 
`git rebase --exec`).

The cause was that [phpstan-drupal includes a file from the Drupal framework](https://github.com/mglaman/phpstan-drupal/pull/149/files) that queries
the runner to figure out which PHPUnit version is being used.

The version returned when running git did not match the actual PHPUnit version installed
which caused the alias that Drupal created to a PHPUnit bridge class to break.

## Problem
The `Version` class uses a `git` command to find the tag of the currently installed package
version for packages that composer has checked out from git. This works when executed 
directly.

However, when used in a git based workflow such as `git rebase --exec` or `git bisect` then
this fails. The cause is that for those commands git will add environment variables that specify
the `GIT_DIR` on which its performing those workflows, so that moving around and calling git 
commands still operates according to the git repository the workflow is being executed on.

As a result when `Version` calls `git describe --tags` this does not use the `.git` folder in the 
working directory of `proc_open` but instead uses the git folder for which the git workflow is
in progress.

## Solution
To remedy this the `Version` class should specify `--git-dir` directly. A few lines above we already
know explicitly what git directory we're interested in. Specifying the argument to git overrides any
environment variables that may be set. This allows the library to work in automated git workflows
invoked from other repositories.