### PR TITLE
Update `.gitattributes` to `export-ignore` additional files

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,6 +1,10 @@
 /.github                export-ignore
+/.phive                 export-ignore
+/.psalm                 export-ignore
+/tools                  export-ignore
 /.gitattributes         export-ignore
 /.gitignore             export-ignore
 /.php-cs-fixer.dist.php export-ignore
+/build.xml              export-ignore
 
 *.php diff=php


### PR DESCRIPTION
Marks `.phive`, `.psalm`, `tools` directories and `build.xml` file with `export-ignore` flag, so when Composer downloads this library as `prefer-dist`, these directories and files are not downloaded.

Saves about 17 MB in storage space, and about 2.8 MB in download size.