### PR TITLE
Avoid spawning a shell for git

### DIFF
--- a/src/Version.php
+++ b/src/Version.php
@@ -83,7 +83,7 @@ final readonly class Version
         }
 
         $process = proc_open(
-            'git describe --tags',
+            ['git', 'describe', '--tags'],
             [
                 1 => ['pipe', 'w'],
                 2 => ['pipe', 'w'],


### PR DESCRIPTION
There is no need to pay for the overhead of spawning a shell. call git directly.