### PR TITLE
Suppressed warnings when Git info cannot be described

### DIFF
--- a/src/Version.php
+++ b/src/Version.php
@@ -85,7 +85,7 @@ final readonly class Version
             return false;
         }
 
-        $process = proc_open(
+        $process = @proc_open(
             ['git', 'describe', '--tags'],
             [
                 1 => ['pipe', 'w'],


### PR DESCRIPTION
Fixes #22 